### PR TITLE
Add entry location tracking for pocket dimension

### DIFF
--- a/src/main/java/io/github/bobisawesome07/block/custom/PocketPortalBlock.kt
+++ b/src/main/java/io/github/bobisawesome07/block/custom/PocketPortalBlock.kt
@@ -17,6 +17,8 @@ import net.minecraft.util.math.BlockPos
 import net.minecraft.world.World
 
 class PocketPortalBlock(settings: Settings) : Block(settings), BlockEntityProvider {
+    private var entryLocation: BlockPos? = null
+
     override fun createBlockEntity(pos: BlockPos, state: BlockState): BlockEntity? {
         return PocketPortalBlockEntity(pos, state)
     }
@@ -32,13 +34,14 @@ class PocketPortalBlock(settings: Settings) : Block(settings), BlockEntityProvid
             return
         }
 
-
         // Get portal entity and check player ownership
         val portalEntity = world.getBlockEntity(pos) as PocketPortalBlockEntity? ?: return
 
         val portalUuid = portalEntity.playerUuid
         val entityUuid = entity.getUuid()
 
+        // Store the entry location
+        entryLocation = pos
 
         // Teleport only if this player created the portal
         if (portalUuid == entityUuid) {

--- a/src/main/java/io/github/bobisawesome07/block/entity/PocketPortalBlockEntity.kt
+++ b/src/main/java/io/github/bobisawesome07/block/entity/PocketPortalBlockEntity.kt
@@ -23,12 +23,20 @@ class PocketPortalBlockEntity(pos: BlockPos, state: BlockState?) :
     @JvmField
     var playerUuid: UUID? = UUID.fromString("0983afc7-7d95-48bb-9c46-e7f4dc5b95cc")
 
+    /** Entry location of the player who created this portal */
+    @JvmField
+    var entryLocation: BlockPos? = null
+
     public override fun writeNbt(tag: NbtCompound) {
         super.writeNbt(tag)
         tag.putInt("Duration", duration)
 
         if (playerUuid != null) {
             tag.putString("PlayerUUID", playerUuid.toString())
+        }
+
+        if (entryLocation != null) {
+            tag.putLong("EntryLocation", entryLocation!!.asLong())
         }
     }
 
@@ -38,6 +46,10 @@ class PocketPortalBlockEntity(pos: BlockPos, state: BlockState?) :
 
         if (tag.contains("PlayerUUID")) {
             playerUuid = UUID.fromString(tag.getString("PlayerUUID"))
+        }
+
+        if (tag.contains("EntryLocation")) {
+            entryLocation = BlockPos.fromLong(tag.getLong("EntryLocation"))
         }
     }
 

--- a/src/main/java/io/github/bobisawesome07/world/dimension/ModDimensions.kt
+++ b/src/main/java/io/github/bobisawesome07/world/dimension/ModDimensions.kt
@@ -8,6 +8,7 @@ import net.minecraft.registry.RegistryKey
 import net.minecraft.registry.RegistryKeys
 import net.minecraft.server.network.ServerPlayerEntity
 import net.minecraft.util.Identifier
+import net.minecraft.util.math.BlockPos
 import net.minecraft.world.Difficulty
 import net.minecraft.world.GameRules
 import net.minecraft.world.World
@@ -30,6 +31,9 @@ object ModDimensions {
 
     // Cache to hold created pocket dimensions
     private val worldCache: MutableMap<String, RuntimeWorldHandle> = ConcurrentHashMap()
+
+    // Cache to hold entry locations
+    private val entryLocationCache: MutableMap<String, BlockPos> = ConcurrentHashMap()
 
     // Chunk generator for pocket dimensions with a barrier floor
     private val pocketGen = BarrierFloorChunkGenerator(
@@ -63,7 +67,26 @@ object ModDimensions {
         )
 
         if (targetWorld != null) {
+            // Store the entry location
+            entryLocationCache[user.uuidAsString] = user.blockPos
+
             serverPlayer.teleport(targetWorld, 0.0, 2.0, 0.0, 0f, 0f)
+        }
+    }
+
+    /**
+     * Teleports a player back to their entry location
+     *
+     * @param world Source world
+     * @param user Player to teleport
+     */
+    @JvmStatic
+    fun tpBackToEntry(world: World?, user: PlayerEntity) {
+        val serverPlayer = user as ServerPlayerEntity
+        val entryLocation = entryLocationCache[user.uuidAsString]
+
+        if (entryLocation != null) {
+            serverPlayer.teleport(world, entryLocation.x.toDouble(), entryLocation.y.toDouble(), entryLocation.z.toDouble(), 0f, 0f)
         }
     }
 


### PR DESCRIPTION
Add tracking of player entry location to pocket dimension and teleportation back to entry location.

* Add `entryLocation` field to `PocketPortalBlock.kt` to store the entry location when the player enters the pocket dimension.
* Update `onEntityCollision` method in `PocketPortalBlock.kt` to store the entry location.
* Add `entryLocation` field to `PocketPortalBlockEntity.kt` to store the entry location along with the player UUID.
* Update `writeNbt` and `readNbt` methods in `PocketPortalBlockEntity.kt` to handle the entry location.
* Add `entryLocationCache` in `ModDimensions.kt` to store entry locations.
* Update `tpToPocket` method in `ModDimensions.kt` to store the entry location when the player enters the pocket dimension.
* Add `tpBackToEntry` method in `ModDimensions.kt` to handle teleportation back to the entry location when the player exits the pocket dimension.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/Bobisawesome07/fractured-mod/pull/33?shareId=3a7cb00e-d6a0-414e-a6c5-43b8a1acb8ad).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Players' entry locations are now saved when teleporting to their pocket dimension.
  - Added the ability for players to return to their original entry location from the pocket dimension.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->